### PR TITLE
fix: properly set current context in new spans

### DIFF
--- a/lib/opentelemetry_ash.ex
+++ b/lib/opentelemetry_ash.ex
@@ -11,7 +11,7 @@ defmodule OpentelemetryAsh do
     parent_span = OpenTelemetry.Tracer.current_span_ctx()
 
     s =
-      OpenTelemetry.Tracer.start_span(parent_span, name, %{
+      OpenTelemetry.Tracer.start_span(name, %{
         kind: :client,
         attributes: %{
           type: type


### PR DESCRIPTION
OpenTelemetry.Tracer.start_span/3 doesn't expect a parent span as the first parameter, it expects otel_ctx

OpenTelemetry.Tracer.start_span/2 automatically set :otel_ctx.get_current() so we use that instead

